### PR TITLE
Chica 438 multiple pid identifiers

### DIFF
--- a/metadata/config.xml
+++ b/metadata/config.xml
@@ -6,7 +6,7 @@
 	<!-- SocketHL7Listener Module Properties -->
 	<id>sockethl7listener</id>
 	<name>sockethl7listener</name>
-	<version>1.3.33</version>
+	<version>1.3.34</version>
 	<package>org.openmrs.module.@MODULE_ID@</package>
 	<author>Meena Sheley and Vibha Anand</author>
 	<description>

--- a/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
+++ b/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
@@ -41,9 +41,6 @@ import ca.uhn.hl7v2.model.v25.segment.PID;
 public class HL7PatientHandler25 implements HL7PatientHandler
 {
 
-	
-	
-	
 	private static final String MRN_PREFIX = "MRN_";
 	private static final String GENERIC_MRN = "MRN_OTHER";
 	protected static final Logger logger = Logger
@@ -485,9 +482,6 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 	}
 
 	
-	/* (non-Javadoc)
-	 * @see org.openmrs.module.sockethl7listener.HL7PatientHandler#getIdentifiers(ca.uhn.hl7v2.model.Message)
-	 */
 	public Set<PatientIdentifier> getIdentifiers(Message message)
 	{
 		PID pid = getPID(message);

--- a/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
+++ b/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
@@ -507,7 +507,7 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 		if (identList.length != 0)
 		{
 			// personAttrList ="mrn:";
-
+			boolean preferred = true;
 			for (CX ident : identList)
 			{
 				// First set up the identifier type; We currently use MRN
@@ -517,6 +517,7 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 				PatientIdentifier pi = new PatientIdentifier();
 				String stIdent = getMRN(ident);
 				String assignAuth = "";
+				
 
 				if (stIdent != null)
 				{
@@ -531,9 +532,10 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 					}
 					pi.setIdentifierType(pit);
 					pi.setIdentifier(stIdent);
-					pi.setPreferred(true);
-
+					pi.setPreferred(preferred);
 					identifiers.add(pi);
+					preferred = false;
+
 
 				} else
 				{
@@ -542,6 +544,7 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 
 			}
 		}
+		
 		return identifiers;
 	}
 

--- a/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
+++ b/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
@@ -41,6 +41,11 @@ import ca.uhn.hl7v2.model.v25.segment.PID;
 public class HL7PatientHandler25 implements HL7PatientHandler
 {
 
+	
+	
+	
+	private static final String MRN_PREFIX = "MRN_";
+	private static final String GENERIC_MRN = "MRN_OTHER";
 	protected static final Logger logger = Logger
 			.getLogger("SocketHandlerLogger");
 	protected static final Logger hl7Logger = Logger.getLogger("HL7Logger");
@@ -496,15 +501,15 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 			identList = pid.getPatientIdentifierList();
 		} catch (RuntimeException e2)
 		{
-			// Unable to extract identifier from PID segment
-			logger
-					.error("Error extracting identifier from PID segment (MRN). ");
-			// Still need to continue. Execute find match without the identifer
+			// Exception in Hapi method for parsing identifiers from PID segment
+			// Execute find match without the identifier. Some applications do not need MRN for lookup.
+			logger.error("Error parsing identifier (MRN) from PID segment. ", e2);
+			return identifiers;   
 		}
 		if (identList == null)
 		{
+			// Some applications do not need MRN for lookup. Execute find match without the identifier
 			logger.warn(" No patient identifier available for this message.");
-			// Still need to continue. Execute find match without the identifer
 			return identifiers;
 		}
 
@@ -529,10 +534,10 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 							.getValue();
 
 					if ((pit = patientService
-							.getPatientIdentifierTypeByName("MRN_" + assignAuth)) == null)
+							.getPatientIdentifierTypeByName(MRN_PREFIX + assignAuth)) == null)
 					{
 						pit = patientService
-								.getPatientIdentifierTypeByName("MRN_OTHER");
+								.getPatientIdentifierTypeByName(GENERIC_MRN);
 					}
 					pi.setIdentifierType(pit);
 					pi.setIdentifier(stIdent);

--- a/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
+++ b/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
@@ -42,7 +42,7 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 {
 
 	private static final String MRN_PREFIX = "MRN_";
-	private static final String GENERIC_MRN = "MRN_OTHER";
+	private static final String GENERIC_ASSIGNING_AUTHORITY = "OTHER";
 	protected static final Logger logger = Logger
 			.getLogger("SocketHandlerLogger");
 	protected static final Logger hl7Logger = Logger.getLogger("HL7Logger");
@@ -481,7 +481,6 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 		return citizenString;
 	}
 
-	
 	public Set<PatientIdentifier> getIdentifiers(Message message)
 	{
 		PID pid = getPID(message);
@@ -493,11 +492,11 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 		{
 
 			identList = pid.getPatientIdentifierList();
-		} catch (RuntimeException e2)
+		} catch (RuntimeException e)
 		{
 			// Exception in Hapi method for parsing identifiers from PID segment
 			// Execute find match without the identifier. Some applications do not need MRN for lookup.
-			logger.error("Error parsing identifier (MRN) from PID segment. ", e2);
+			logger.error("Error parsing identifier (MRN) from PID segment. ", e);
 			return identifiers;   
 		}
 		if (identList == null)
@@ -531,7 +530,7 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 							.getPatientIdentifierTypeByName(MRN_PREFIX + assignAuth)) == null)
 					{
 						pit = patientService
-								.getPatientIdentifierTypeByName(GENERIC_MRN);
+								.getPatientIdentifierTypeByName(MRN_PREFIX + GENERIC_ASSIGNING_AUTHORITY);
 					}
 					pi.setIdentifierType(pit);
 					pi.setIdentifier(stIdent);

--- a/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
+++ b/src/org/openmrs/module/sockethl7listener/HL7PatientHandler25.java
@@ -479,6 +479,10 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 		return citizenString;
 	}
 
+	
+	/* (non-Javadoc)
+	 * @see org.openmrs.module.sockethl7listener.HL7PatientHandler#getIdentifiers(ca.uhn.hl7v2.model.Message)
+	 */
 	public Set<PatientIdentifier> getIdentifiers(Message message)
 	{
 		PID pid = getPID(message);
@@ -506,7 +510,7 @@ public class HL7PatientHandler25 implements HL7PatientHandler
 
 		if (identList.length != 0)
 		{
-			// personAttrList ="mrn:";
+			//MES - CHICA-438 - When there are > 1 identifiers, set only the first to preferred.
 			boolean preferred = true;
 			for (CX ident : identList)
 			{


### PR DESCRIPTION
The registration messages may change format to have more than one patient identifier listed. If the registration hl7 message has multiple patient identifiers, the SocketHL7Listener module patient handler sets both as preferred. This can be a problem when using OpenMRS Patient method getPatientIdentifier(), which pulls the preferred identifier.  This fix prevents patient matching errors if the HL7 format is modified.